### PR TITLE
Add 3 more tiers of altars. Materials are temp for now, change in config

### DIFF
--- a/src/main/java/WayofTime/alchemicalWizardry/AlchemicalWizardry.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/AlchemicalWizardry.java
@@ -305,12 +305,15 @@ public class AlchemicalWizardry
     public static boolean causeHungerChatMessage = true;
     public static boolean disableBoundToolsRightClick;
 
-    public static BlockStack[] secondTierRunes = new BlockStack[10];
-    public static BlockStack[] thirdTierRunes = new BlockStack[10];
-    public static BlockStack[] fourthTierRunes = new BlockStack[10];
-    public static BlockStack[] fifthTierRunes = new BlockStack[10];
-    public static BlockStack[] sixthTierRunes = new BlockStack[10];
-    public static BlockStack[] specialAltarBlock = new BlockStack[7];
+    public static BlockStack[] secondTierRunes = new BlockStack[10];//Did I need to make these higher?
+    public static BlockStack[] thirdTierRunes = new BlockStack[10];//To account for the new runes?
+    public static BlockStack[] fourthTierRunes = new BlockStack[10];//But it works anyway?
+    public static BlockStack[] fifthTierRunes = new BlockStack[10];//Also, why x+1? Do they not count 0?
+    public static BlockStack[] sixthTierRunes = new BlockStack[13];//Or maybe all the metadat different ones count as the same?
+    public static BlockStack[] seventhTierRunes = new BlockStack[13];//But then there'd still be 5 types
+    public static BlockStack[] eighthTierRunes = new BlockStack[16];
+    public static BlockStack[] ninthTierRunes = new BlockStack[16];
+    public static BlockStack[] specialAltarBlock = new BlockStack[13];
 
     public static int lpPerSelfSacrifice = 200;
     public static int lpPerSelfSacrificeSoulFray = 20;

--- a/src/main/java/WayofTime/alchemicalWizardry/BloodMagicConfiguration.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/BloodMagicConfiguration.java
@@ -350,7 +350,7 @@ public class BloodMagicConfiguration
 
 	public static void finishLoading()
 	{
-		AlchemicalWizardry.secondTierRunes = BloodMagicConfiguration.getAltarRunesForTier("secondTier", new BlockStack[] {
+		AlchemicalWizardry.secondTierRunes = BloodMagicConfiguration.getAltarRunesForTier("2ndTier", new BlockStack[] {
 			new BlockStack(ModBlocks.bloodRune, 0),
 			new BlockStack(ModBlocks.speedRune, 0),
 			new BlockStack(ModBlocks.efficiencyRune, 0),
@@ -362,7 +362,7 @@ public class BloodMagicConfiguration
 			new BlockStack(ModBlocks.bloodRune, 4),
 			new BlockStack(ModBlocks.bloodRune, 5)			
 		});
-		AlchemicalWizardry.thirdTierRunes = BloodMagicConfiguration.getAltarRunesForTier("thirdTier", new BlockStack[] {
+		AlchemicalWizardry.thirdTierRunes = BloodMagicConfiguration.getAltarRunesForTier("3rdTier", new BlockStack[] {
 			new BlockStack(ModBlocks.bloodRune, 0),
 			new BlockStack(ModBlocks.speedRune, 0),
 			new BlockStack(ModBlocks.efficiencyRune, 0),
@@ -374,7 +374,7 @@ public class BloodMagicConfiguration
 			new BlockStack(ModBlocks.bloodRune, 4),
 			new BlockStack(ModBlocks.bloodRune, 5)
 		});
-		AlchemicalWizardry.fourthTierRunes = BloodMagicConfiguration.getAltarRunesForTier("fourthTier", new BlockStack[] {
+		AlchemicalWizardry.fourthTierRunes = BloodMagicConfiguration.getAltarRunesForTier("4thTier", new BlockStack[] {
 			new BlockStack(ModBlocks.bloodRune, 0),
 			new BlockStack(ModBlocks.speedRune, 0),
 			new BlockStack(ModBlocks.efficiencyRune, 0),
@@ -386,7 +386,19 @@ public class BloodMagicConfiguration
 			new BlockStack(ModBlocks.bloodRune, 4),
 			new BlockStack(ModBlocks.bloodRune, 5)
 		});
-		AlchemicalWizardry.fifthTierRunes = BloodMagicConfiguration.getAltarRunesForTier("fifthTier", new BlockStack[] {
+		AlchemicalWizardry.fifthTierRunes = BloodMagicConfiguration.getAltarRunesForTier("5thTier", new BlockStack[] {
+			new BlockStack(ModBlocks.bloodRune, 0),
+			new BlockStack(ModBlocks.speedRune, 0),
+			new BlockStack(ModBlocks.efficiencyRune, 0),
+			new BlockStack(ModBlocks.runeOfSacrifice, 0),
+			new BlockStack(ModBlocks.runeOfSelfSacrifice, 0),
+			new BlockStack(ModBlocks.bloodRune, 1),
+			new BlockStack(ModBlocks.bloodRune, 2),
+			new BlockStack(ModBlocks.bloodRune, 3),
+			new BlockStack(ModBlocks.bloodRune, 4),
+			new BlockStack(ModBlocks.bloodRune, 5)
+		});
+		AlchemicalWizardry.sixthTierRunes = BloodMagicConfiguration.getAltarRunesForTier("6thTier", new BlockStack[] {
 			new BlockStack(ModBlocks.bloodRune, 0),
 			new BlockStack(ModBlocks.speedRune, 0),
 			new BlockStack(ModBlocks.efficiencyRune, 0),
@@ -398,34 +410,73 @@ public class BloodMagicConfiguration
 			new BlockStack(ModBlocks.bloodRune, 4),
 			new BlockStack(ModBlocks.bloodRune, 5),
 			new BlockStack(ModBlocks.bloodRune, 6),//super runes from this tier on
-			new BlockStack(ModBlocks.bloodRune, 8),
+			new BlockStack(ModBlocks.bloodRune, 8),				
 			new BlockStack(ModBlocks.bloodRune, 10)
-			
 		});
-		AlchemicalWizardry.sixthTierRunes = BloodMagicConfiguration.getAltarRunesForTier("sixthTier", new BlockStack[] {
-			new BlockStack(ModBlocks.bloodRune, 0),
-			new BlockStack(ModBlocks.speedRune, 0),
-			new BlockStack(ModBlocks.efficiencyRune, 0),
-			new BlockStack(ModBlocks.runeOfSacrifice, 0),
-			new BlockStack(ModBlocks.runeOfSelfSacrifice, 0),
-			new BlockStack(ModBlocks.bloodRune, 1),
-			new BlockStack(ModBlocks.bloodRune, 2),
-			new BlockStack(ModBlocks.bloodRune, 3),
-			new BlockStack(ModBlocks.bloodRune, 4),
-			new BlockStack(ModBlocks.bloodRune, 5),
-			new BlockStack(ModBlocks.bloodRune, 6),//super runes from this tier on
-			new BlockStack(ModBlocks.bloodRune, 7),//change later when more tiers added
-			new BlockStack(ModBlocks.bloodRune, 8),
-			new BlockStack(ModBlocks.bloodRune, 9),
-			new BlockStack(ModBlocks.bloodRune, 10),
-			new BlockStack(ModBlocks.bloodRune, 11)
-		});
+		AlchemicalWizardry.seventhTierRunes = BloodMagicConfiguration.getAltarRunesForTier("7thTier", new BlockStack[] {
+				new BlockStack(ModBlocks.bloodRune, 0),
+				new BlockStack(ModBlocks.speedRune, 0),
+				new BlockStack(ModBlocks.efficiencyRune, 0),
+				new BlockStack(ModBlocks.runeOfSacrifice, 0),
+				new BlockStack(ModBlocks.runeOfSelfSacrifice, 0),
+				new BlockStack(ModBlocks.bloodRune, 1),
+				new BlockStack(ModBlocks.bloodRune, 2),
+				new BlockStack(ModBlocks.bloodRune, 3),
+				new BlockStack(ModBlocks.bloodRune, 4),
+				new BlockStack(ModBlocks.bloodRune, 5),
+				new BlockStack(ModBlocks.bloodRune, 6),		
+				new BlockStack(ModBlocks.bloodRune, 8),				
+				new BlockStack(ModBlocks.bloodRune, 10)
+				
+			});
+		AlchemicalWizardry.eighthTierRunes = BloodMagicConfiguration.getAltarRunesForTier("8thTier", new BlockStack[] {
+				new BlockStack(ModBlocks.bloodRune, 0),
+				new BlockStack(ModBlocks.speedRune, 0),
+				new BlockStack(ModBlocks.efficiencyRune, 0),
+				new BlockStack(ModBlocks.runeOfSacrifice, 0),
+				new BlockStack(ModBlocks.runeOfSelfSacrifice, 0),
+				new BlockStack(ModBlocks.bloodRune, 1),
+				new BlockStack(ModBlocks.bloodRune, 2),
+				new BlockStack(ModBlocks.bloodRune, 3),
+				new BlockStack(ModBlocks.bloodRune, 4),
+				new BlockStack(ModBlocks.bloodRune, 5),
+				new BlockStack(ModBlocks.bloodRune, 6),
+				new BlockStack(ModBlocks.bloodRune, 7),//ultra runes from this tier on
+				new BlockStack(ModBlocks.bloodRune, 8),
+				new BlockStack(ModBlocks.bloodRune, 9),
+				new BlockStack(ModBlocks.bloodRune, 10),
+				new BlockStack(ModBlocks.bloodRune, 11)
+			});
+		AlchemicalWizardry.ninthTierRunes = BloodMagicConfiguration.getAltarRunesForTier("9thTier", new BlockStack[] {
+				new BlockStack(ModBlocks.bloodRune, 0),
+				new BlockStack(ModBlocks.speedRune, 0),
+				new BlockStack(ModBlocks.efficiencyRune, 0),
+				new BlockStack(ModBlocks.runeOfSacrifice, 0),
+				new BlockStack(ModBlocks.runeOfSelfSacrifice, 0),
+				new BlockStack(ModBlocks.bloodRune, 1),
+				new BlockStack(ModBlocks.bloodRune, 2),
+				new BlockStack(ModBlocks.bloodRune, 3),
+				new BlockStack(ModBlocks.bloodRune, 4),
+				new BlockStack(ModBlocks.bloodRune, 5),
+				new BlockStack(ModBlocks.bloodRune, 6),
+				new BlockStack(ModBlocks.bloodRune, 7),
+				new BlockStack(ModBlocks.bloodRune, 8),
+				new BlockStack(ModBlocks.bloodRune, 9),
+				new BlockStack(ModBlocks.bloodRune, 10),
+				new BlockStack(ModBlocks.bloodRune, 11)
+			});
 		AlchemicalWizardry.specialAltarBlock = getAltarRunesForTier("specialBlocks", new BlockStack[] {
 			new BlockStack(Blocks.stonebrick, 0),
 			new BlockStack(Blocks.glowstone, 0),
 			new BlockStack(Blocks.stonebrick, 0),
 			new BlockStack(ModBlocks.largeBloodStoneBrick, 0),
 			new BlockStack(Blocks.beacon, 0),
+			new BlockStack(Blocks.stonebrick, 0),
+			new BlockStack(ModBlocks.blockCrystal, 0),
+			new BlockStack(Blocks.stonebrick, 0),
+			new BlockStack(ModBlocks.blockCrystal, 0),
+			new BlockStack(Blocks.stonebrick, 0),
+			new BlockStack(ModBlocks.blockCrystal, 0),
 			new BlockStack(Blocks.stonebrick, 0),
 			new BlockStack(ModBlocks.blockCrystal, 0)
 		});

--- a/src/main/java/WayofTime/alchemicalWizardry/common/bloodAltarUpgrade/UpgradedAltars.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/common/bloodAltarUpgrade/UpgradedAltars.java
@@ -17,7 +17,10 @@ public class UpgradedAltars
     public static List<AltarComponent> fourthTierAltar = new ArrayList<AltarComponent>();
     public static List<AltarComponent> fifthTierAltar = new ArrayList<AltarComponent>();
     public static List<AltarComponent> sixthTierAltar = new ArrayList<AltarComponent>();
-    public static int highestAltar = 6;
+    public static List<AltarComponent> seventhTierAltar = new ArrayList<AltarComponent>();
+    public static List<AltarComponent> eighthTierAltar = new ArrayList<AltarComponent>();
+    public static List<AltarComponent> ninthTierAltar = new ArrayList<AltarComponent>();
+    public static int highestAltar = 9;
 
     public static int isAltarValid(World world, int x, int y, int z)
     {
@@ -67,11 +70,17 @@ public class UpgradedAltars
                 return AlchemicalWizardry.fifthTierRunes;
             case 6:
                 return AlchemicalWizardry.sixthTierRunes;
+            case 7:
+                return AlchemicalWizardry.seventhTierRunes;
+            case 8:
+                return AlchemicalWizardry.eighthTierRunes;
+            case 9:
+                return AlchemicalWizardry.ninthTierRunes;
             default:
                 return null;
         }
     }
-    private static boolean checkAltarComponent(AltarComponent altarComponent, IBlockAccess world, int x, int y, int z, int altarTier)
+    private static boolean checkAltarComponent(AltarComponent altarComponent, IBlockAccess world, int x, int y, int z, int altarTier)//ugh
     {
         Block block = world.getBlock(x + altarComponent.getX(), y + altarComponent.getY(), z + altarComponent.getZ());
         int metadata = world.getBlockMetadata(x + altarComponent.getX(), y + altarComponent.getY(), z + altarComponent.getZ());
@@ -281,6 +290,183 @@ public class UpgradedAltars
             sixthTierAltar.add(new AltarComponent(i, -5, 11, AlchemicalWizardry.sixthTierRunes[0].getBlock(), AlchemicalWizardry.sixthTierRunes[0].getMeta(), true, true));
             sixthTierAltar.add(new AltarComponent(i, -5, -11, AlchemicalWizardry.sixthTierRunes[0].getBlock(), AlchemicalWizardry.sixthTierRunes[0].getMeta(), true, true));
         }
+        
+        //new
+        seventhTierAltar.addAll(sixthTierAltar);
+        for (int i = -5; i <= 4; i++)
+        {
+        	seventhTierAltar.add(new AltarComponent(15, i, 15, AlchemicalWizardry.specialAltarBlock[7].getBlock(), AlchemicalWizardry.specialAltarBlock[7].getMeta(), false, false));
+        	seventhTierAltar.add(new AltarComponent(-15, i, -15, AlchemicalWizardry.specialAltarBlock[7].getBlock(), AlchemicalWizardry.specialAltarBlock[7].getMeta(), false, false));
+        	seventhTierAltar.add(new AltarComponent(15, i, -15, AlchemicalWizardry.specialAltarBlock[7].getBlock(), AlchemicalWizardry.specialAltarBlock[7].getMeta(), false, false));
+        	seventhTierAltar.add(new AltarComponent(-15, i, 15, AlchemicalWizardry.specialAltarBlock[7].getBlock(), AlchemicalWizardry.specialAltarBlock[7].getMeta(), false, false));
+        }
+        seventhTierAltar.add(new AltarComponent(15, 5, 15, AlchemicalWizardry.specialAltarBlock[8].getBlock(), AlchemicalWizardry.specialAltarBlock[8].getMeta(), false, false));
+        seventhTierAltar.add(new AltarComponent(-15, 5, -15, AlchemicalWizardry.specialAltarBlock[8].getBlock(), AlchemicalWizardry.specialAltarBlock[8].getMeta(), false, false));
+        seventhTierAltar.add(new AltarComponent(15, 5, -15, AlchemicalWizardry.specialAltarBlock[8].getBlock(), AlchemicalWizardry.specialAltarBlock[8].getMeta(), false, false));
+        seventhTierAltar.add(new AltarComponent(-15, 5, 15, AlchemicalWizardry.specialAltarBlock[8].getBlock(), AlchemicalWizardry.specialAltarBlock[8].getMeta(), false, false));
+        //bases for 7th
+        seventhTierAltar.add(new AltarComponent(-16, -6, -14, AlchemicalWizardry.specialAltarBlock[6].getBlock(), AlchemicalWizardry.specialAltarBlock[6].getMeta(), false, false));
+        seventhTierAltar.add(new AltarComponent(-16, -6, -15, AlchemicalWizardry.specialAltarBlock[6].getBlock(), AlchemicalWizardry.specialAltarBlock[6].getMeta(), false, false));
+        seventhTierAltar.add(new AltarComponent(-16, -6, -16, AlchemicalWizardry.specialAltarBlock[6].getBlock(), AlchemicalWizardry.specialAltarBlock[6].getMeta(), false, false));
+        seventhTierAltar.add(new AltarComponent(-15, -6, -14, AlchemicalWizardry.specialAltarBlock[6].getBlock(), AlchemicalWizardry.specialAltarBlock[6].getMeta(), false, false));
+        seventhTierAltar.add(new AltarComponent(-15, -6, -15, AlchemicalWizardry.specialAltarBlock[6].getBlock(), AlchemicalWizardry.specialAltarBlock[6].getMeta(), false, false));
+        seventhTierAltar.add(new AltarComponent(-15, -6, -16, AlchemicalWizardry.specialAltarBlock[6].getBlock(), AlchemicalWizardry.specialAltarBlock[6].getMeta(), false, false));
+        seventhTierAltar.add(new AltarComponent(-14, -6, -14, AlchemicalWizardry.specialAltarBlock[6].getBlock(), AlchemicalWizardry.specialAltarBlock[6].getMeta(), false, false));
+        seventhTierAltar.add(new AltarComponent(-14, -6, -15, AlchemicalWizardry.specialAltarBlock[6].getBlock(), AlchemicalWizardry.specialAltarBlock[6].getMeta(), false, false));
+        seventhTierAltar.add(new AltarComponent(-14, -6, -16, AlchemicalWizardry.specialAltarBlock[6].getBlock(), AlchemicalWizardry.specialAltarBlock[6].getMeta(), false, false));
+        
+        seventhTierAltar.add(new AltarComponent(16, -6, -14, AlchemicalWizardry.specialAltarBlock[6].getBlock(), AlchemicalWizardry.specialAltarBlock[6].getMeta(), false, false));
+        seventhTierAltar.add(new AltarComponent(16, -6, -15, AlchemicalWizardry.specialAltarBlock[6].getBlock(), AlchemicalWizardry.specialAltarBlock[6].getMeta(), false, false));
+        seventhTierAltar.add(new AltarComponent(16, -6, -16, AlchemicalWizardry.specialAltarBlock[6].getBlock(), AlchemicalWizardry.specialAltarBlock[6].getMeta(), false, false));
+        seventhTierAltar.add(new AltarComponent(15, -6, -14, AlchemicalWizardry.specialAltarBlock[6].getBlock(), AlchemicalWizardry.specialAltarBlock[6].getMeta(), false, false));
+        seventhTierAltar.add(new AltarComponent(15, -6, -15, AlchemicalWizardry.specialAltarBlock[6].getBlock(), AlchemicalWizardry.specialAltarBlock[6].getMeta(), false, false));
+        seventhTierAltar.add(new AltarComponent(15, -6, -16, AlchemicalWizardry.specialAltarBlock[6].getBlock(), AlchemicalWizardry.specialAltarBlock[6].getMeta(), false, false));
+        seventhTierAltar.add(new AltarComponent(14, -6, -14, AlchemicalWizardry.specialAltarBlock[6].getBlock(), AlchemicalWizardry.specialAltarBlock[6].getMeta(), false, false));
+        seventhTierAltar.add(new AltarComponent(14, -6, -15, AlchemicalWizardry.specialAltarBlock[6].getBlock(), AlchemicalWizardry.specialAltarBlock[6].getMeta(), false, false));
+        seventhTierAltar.add(new AltarComponent(14, -6, -16, AlchemicalWizardry.specialAltarBlock[6].getBlock(), AlchemicalWizardry.specialAltarBlock[6].getMeta(), false, false));
+        
+        seventhTierAltar.add(new AltarComponent(-16, -6, 14, AlchemicalWizardry.specialAltarBlock[6].getBlock(), AlchemicalWizardry.specialAltarBlock[6].getMeta(), false, false));
+        seventhTierAltar.add(new AltarComponent(-16, -6, 15, AlchemicalWizardry.specialAltarBlock[6].getBlock(), AlchemicalWizardry.specialAltarBlock[6].getMeta(), false, false));
+        seventhTierAltar.add(new AltarComponent(-16, -6, 16, AlchemicalWizardry.specialAltarBlock[6].getBlock(), AlchemicalWizardry.specialAltarBlock[6].getMeta(), false, false));
+        seventhTierAltar.add(new AltarComponent(-15, -6, 14, AlchemicalWizardry.specialAltarBlock[6].getBlock(), AlchemicalWizardry.specialAltarBlock[6].getMeta(), false, false));
+        seventhTierAltar.add(new AltarComponent(-15, -6, 15, AlchemicalWizardry.specialAltarBlock[6].getBlock(), AlchemicalWizardry.specialAltarBlock[6].getMeta(), false, false));
+        seventhTierAltar.add(new AltarComponent(-15, -6, 16, AlchemicalWizardry.specialAltarBlock[6].getBlock(), AlchemicalWizardry.specialAltarBlock[6].getMeta(), false, false));
+        seventhTierAltar.add(new AltarComponent(-14, -6, 14, AlchemicalWizardry.specialAltarBlock[6].getBlock(), AlchemicalWizardry.specialAltarBlock[6].getMeta(), false, false));
+        seventhTierAltar.add(new AltarComponent(-14, -6, 15, AlchemicalWizardry.specialAltarBlock[6].getBlock(), AlchemicalWizardry.specialAltarBlock[6].getMeta(), false, false));
+        seventhTierAltar.add(new AltarComponent(-14, -6, 16, AlchemicalWizardry.specialAltarBlock[6].getBlock(), AlchemicalWizardry.specialAltarBlock[6].getMeta(), false, false));
+        
+        seventhTierAltar.add(new AltarComponent(16, -6, 14, AlchemicalWizardry.specialAltarBlock[6].getBlock(), AlchemicalWizardry.specialAltarBlock[6].getMeta(), false, false));
+        seventhTierAltar.add(new AltarComponent(16, -6, 15, AlchemicalWizardry.specialAltarBlock[6].getBlock(), AlchemicalWizardry.specialAltarBlock[6].getMeta(), false, false));
+        seventhTierAltar.add(new AltarComponent(16, -6, 16, AlchemicalWizardry.specialAltarBlock[6].getBlock(), AlchemicalWizardry.specialAltarBlock[6].getMeta(), false, false));
+        seventhTierAltar.add(new AltarComponent(15, -6, 14, AlchemicalWizardry.specialAltarBlock[6].getBlock(), AlchemicalWizardry.specialAltarBlock[6].getMeta(), false, false));
+        seventhTierAltar.add(new AltarComponent(15, -6, 15, AlchemicalWizardry.specialAltarBlock[6].getBlock(), AlchemicalWizardry.specialAltarBlock[6].getMeta(), false, false));
+        seventhTierAltar.add(new AltarComponent(15, -6, 16, AlchemicalWizardry.specialAltarBlock[6].getBlock(), AlchemicalWizardry.specialAltarBlock[6].getMeta(), false, false));
+        seventhTierAltar.add(new AltarComponent(14, -6, 14, AlchemicalWizardry.specialAltarBlock[6].getBlock(), AlchemicalWizardry.specialAltarBlock[6].getMeta(), false, false));
+        seventhTierAltar.add(new AltarComponent(14, -6, 15, AlchemicalWizardry.specialAltarBlock[6].getBlock(), AlchemicalWizardry.specialAltarBlock[6].getMeta(), false, false));
+        seventhTierAltar.add(new AltarComponent(14, -6, 16, AlchemicalWizardry.specialAltarBlock[6].getBlock(), AlchemicalWizardry.specialAltarBlock[6].getMeta(), false, false));
+        for (int i = -12; i <= 12; i++)
+        {
+        	seventhTierAltar.add(new AltarComponent(15, -6, i, AlchemicalWizardry.seventhTierRunes[0].getBlock(), AlchemicalWizardry.seventhTierRunes[0].getMeta(), true, true));
+        	seventhTierAltar.add(new AltarComponent(-15, -6, i, AlchemicalWizardry.seventhTierRunes[0].getBlock(), AlchemicalWizardry.seventhTierRunes[0].getMeta(), true, true));
+        	seventhTierAltar.add(new AltarComponent(i, -6, 15, AlchemicalWizardry.seventhTierRunes[0].getBlock(), AlchemicalWizardry.seventhTierRunes[0].getMeta(), true, true));
+        	seventhTierAltar.add(new AltarComponent(i, -6, -15, AlchemicalWizardry.seventhTierRunes[0].getBlock(), AlchemicalWizardry.seventhTierRunes[0].getMeta(), true, true));
+        }
+        
+        eighthTierAltar.addAll(seventhTierAltar);
+        for (int i = -6; i <= 6; i++)
+        {
+        	eighthTierAltar.add(new AltarComponent(19, i, 19, AlchemicalWizardry.specialAltarBlock[9].getBlock(), AlchemicalWizardry.specialAltarBlock[9].getMeta(), false, false));
+        	eighthTierAltar.add(new AltarComponent(-19, i, -19, AlchemicalWizardry.specialAltarBlock[9].getBlock(), AlchemicalWizardry.specialAltarBlock[9].getMeta(), false, false));
+        	eighthTierAltar.add(new AltarComponent(19, i, -19, AlchemicalWizardry.specialAltarBlock[9].getBlock(), AlchemicalWizardry.specialAltarBlock[9].getMeta(), false, false));
+        	eighthTierAltar.add(new AltarComponent(-19, i, 19, AlchemicalWizardry.specialAltarBlock[9].getBlock(), AlchemicalWizardry.specialAltarBlock[9].getMeta(), false, false));
+        }
+        eighthTierAltar.add(new AltarComponent(19, 7, 19, AlchemicalWizardry.specialAltarBlock[10].getBlock(), AlchemicalWizardry.specialAltarBlock[10].getMeta(), false, false));
+        eighthTierAltar.add(new AltarComponent(-19, 7, -19, AlchemicalWizardry.specialAltarBlock[10].getBlock(), AlchemicalWizardry.specialAltarBlock[10].getMeta(), false, false));
+        eighthTierAltar.add(new AltarComponent(19, 7, -19, AlchemicalWizardry.specialAltarBlock[10].getBlock(), AlchemicalWizardry.specialAltarBlock[10].getMeta(), false, false));
+        eighthTierAltar.add(new AltarComponent(-19, 7, 19, AlchemicalWizardry.specialAltarBlock[10].getBlock(), AlchemicalWizardry.specialAltarBlock[10].getMeta(), false, false));
+        //bases for 8th
+        eighthTierAltar.add(new AltarComponent(-18, -7, -18, AlchemicalWizardry.specialAltarBlock[8].getBlock(), AlchemicalWizardry.specialAltarBlock[8].getMeta(), false, false));
+        eighthTierAltar.add(new AltarComponent(-18, -7, -19, AlchemicalWizardry.specialAltarBlock[8].getBlock(), AlchemicalWizardry.specialAltarBlock[8].getMeta(), false, false));
+        eighthTierAltar.add(new AltarComponent(-18, -7, -20, AlchemicalWizardry.specialAltarBlock[8].getBlock(), AlchemicalWizardry.specialAltarBlock[8].getMeta(), false, false));
+        eighthTierAltar.add(new AltarComponent(-19, -7, -18, AlchemicalWizardry.specialAltarBlock[8].getBlock(), AlchemicalWizardry.specialAltarBlock[8].getMeta(), false, false));
+        eighthTierAltar.add(new AltarComponent(-19, -7, -19, AlchemicalWizardry.specialAltarBlock[8].getBlock(), AlchemicalWizardry.specialAltarBlock[8].getMeta(), false, false));
+        eighthTierAltar.add(new AltarComponent(-19, -7, -20, AlchemicalWizardry.specialAltarBlock[8].getBlock(), AlchemicalWizardry.specialAltarBlock[8].getMeta(), false, false));
+        eighthTierAltar.add(new AltarComponent(-20, -7, -18, AlchemicalWizardry.specialAltarBlock[8].getBlock(), AlchemicalWizardry.specialAltarBlock[8].getMeta(), false, false));
+        eighthTierAltar.add(new AltarComponent(-20, -7, -19, AlchemicalWizardry.specialAltarBlock[8].getBlock(), AlchemicalWizardry.specialAltarBlock[8].getMeta(), false, false));
+        eighthTierAltar.add(new AltarComponent(-20, -7, -20, AlchemicalWizardry.specialAltarBlock[8].getBlock(), AlchemicalWizardry.specialAltarBlock[8].getMeta(), false, false));
+        
+        eighthTierAltar.add(new AltarComponent(18, -7, -18, AlchemicalWizardry.specialAltarBlock[8].getBlock(), AlchemicalWizardry.specialAltarBlock[8].getMeta(), false, false));
+        eighthTierAltar.add(new AltarComponent(18, -7, -19, AlchemicalWizardry.specialAltarBlock[8].getBlock(), AlchemicalWizardry.specialAltarBlock[8].getMeta(), false, false));
+        eighthTierAltar.add(new AltarComponent(18, -7, -20, AlchemicalWizardry.specialAltarBlock[8].getBlock(), AlchemicalWizardry.specialAltarBlock[8].getMeta(), false, false));
+        eighthTierAltar.add(new AltarComponent(19, -7, -18, AlchemicalWizardry.specialAltarBlock[8].getBlock(), AlchemicalWizardry.specialAltarBlock[8].getMeta(), false, false));
+        eighthTierAltar.add(new AltarComponent(19, -7, -19, AlchemicalWizardry.specialAltarBlock[8].getBlock(), AlchemicalWizardry.specialAltarBlock[8].getMeta(), false, false));
+        eighthTierAltar.add(new AltarComponent(19, -7, -20, AlchemicalWizardry.specialAltarBlock[8].getBlock(), AlchemicalWizardry.specialAltarBlock[8].getMeta(), false, false));
+        eighthTierAltar.add(new AltarComponent(20, -7, -18, AlchemicalWizardry.specialAltarBlock[8].getBlock(), AlchemicalWizardry.specialAltarBlock[8].getMeta(), false, false));
+        eighthTierAltar.add(new AltarComponent(20, -7, -19, AlchemicalWizardry.specialAltarBlock[8].getBlock(), AlchemicalWizardry.specialAltarBlock[8].getMeta(), false, false));
+        eighthTierAltar.add(new AltarComponent(20, -7, -20, AlchemicalWizardry.specialAltarBlock[8].getBlock(), AlchemicalWizardry.specialAltarBlock[8].getMeta(), false, false));
+        
+        eighthTierAltar.add(new AltarComponent(-18, -7, 18, AlchemicalWizardry.specialAltarBlock[8].getBlock(), AlchemicalWizardry.specialAltarBlock[8].getMeta(), false, false));
+        eighthTierAltar.add(new AltarComponent(-18, -7, 19, AlchemicalWizardry.specialAltarBlock[8].getBlock(), AlchemicalWizardry.specialAltarBlock[8].getMeta(), false, false));
+        eighthTierAltar.add(new AltarComponent(-18, -7, 20, AlchemicalWizardry.specialAltarBlock[8].getBlock(), AlchemicalWizardry.specialAltarBlock[8].getMeta(), false, false));
+        eighthTierAltar.add(new AltarComponent(-19, -7, 18, AlchemicalWizardry.specialAltarBlock[8].getBlock(), AlchemicalWizardry.specialAltarBlock[8].getMeta(), false, false));
+        eighthTierAltar.add(new AltarComponent(-19, -7, 19, AlchemicalWizardry.specialAltarBlock[8].getBlock(), AlchemicalWizardry.specialAltarBlock[8].getMeta(), false, false));
+        eighthTierAltar.add(new AltarComponent(-19, -7, 20, AlchemicalWizardry.specialAltarBlock[8].getBlock(), AlchemicalWizardry.specialAltarBlock[8].getMeta(), false, false));
+        eighthTierAltar.add(new AltarComponent(-20, -7, 18, AlchemicalWizardry.specialAltarBlock[8].getBlock(), AlchemicalWizardry.specialAltarBlock[8].getMeta(), false, false));
+        eighthTierAltar.add(new AltarComponent(-20, -7, 19, AlchemicalWizardry.specialAltarBlock[8].getBlock(), AlchemicalWizardry.specialAltarBlock[8].getMeta(), false, false));
+        eighthTierAltar.add(new AltarComponent(-20, -7, 20, AlchemicalWizardry.specialAltarBlock[8].getBlock(), AlchemicalWizardry.specialAltarBlock[8].getMeta(), false, false));
+        
+        eighthTierAltar.add(new AltarComponent(18, -7, 18, AlchemicalWizardry.specialAltarBlock[8].getBlock(), AlchemicalWizardry.specialAltarBlock[8].getMeta(), false, false));
+        eighthTierAltar.add(new AltarComponent(18, -7, 19, AlchemicalWizardry.specialAltarBlock[8].getBlock(), AlchemicalWizardry.specialAltarBlock[8].getMeta(), false, false));
+        eighthTierAltar.add(new AltarComponent(18, -7, 20, AlchemicalWizardry.specialAltarBlock[8].getBlock(), AlchemicalWizardry.specialAltarBlock[8].getMeta(), false, false));
+        eighthTierAltar.add(new AltarComponent(19, -7, 18, AlchemicalWizardry.specialAltarBlock[8].getBlock(), AlchemicalWizardry.specialAltarBlock[8].getMeta(), false, false));
+        eighthTierAltar.add(new AltarComponent(19, -7, 19, AlchemicalWizardry.specialAltarBlock[8].getBlock(), AlchemicalWizardry.specialAltarBlock[8].getMeta(), false, false));
+        eighthTierAltar.add(new AltarComponent(19, -7, 20, AlchemicalWizardry.specialAltarBlock[8].getBlock(), AlchemicalWizardry.specialAltarBlock[8].getMeta(), false, false));
+        eighthTierAltar.add(new AltarComponent(20, -7, 18, AlchemicalWizardry.specialAltarBlock[8].getBlock(), AlchemicalWizardry.specialAltarBlock[8].getMeta(), false, false));
+        eighthTierAltar.add(new AltarComponent(20, -7, 19, AlchemicalWizardry.specialAltarBlock[8].getBlock(), AlchemicalWizardry.specialAltarBlock[8].getMeta(), false, false));
+        eighthTierAltar.add(new AltarComponent(20, -7, 20, AlchemicalWizardry.specialAltarBlock[8].getBlock(), AlchemicalWizardry.specialAltarBlock[8].getMeta(), false, false));
+        
+        for (int i = -16; i <= 16; i++)
+        {
+        	eighthTierAltar.add(new AltarComponent(19, -7, i, AlchemicalWizardry.eighthTierRunes[0].getBlock(), AlchemicalWizardry.eighthTierRunes[0].getMeta(), true, true));
+        	eighthTierAltar.add(new AltarComponent(-19, -7, i, AlchemicalWizardry.eighthTierRunes[0].getBlock(), AlchemicalWizardry.eighthTierRunes[0].getMeta(), true, true));
+        	eighthTierAltar.add(new AltarComponent(i, -7, 19, AlchemicalWizardry.eighthTierRunes[0].getBlock(), AlchemicalWizardry.eighthTierRunes[0].getMeta(), true, true));
+        	eighthTierAltar.add(new AltarComponent(i, -7, -19, AlchemicalWizardry.eighthTierRunes[0].getBlock(), AlchemicalWizardry.eighthTierRunes[0].getMeta(), true, true));
+        }
+        
+        ninthTierAltar.addAll(eighthTierAltar);
+        for (int i = -6; i <= 9; i++)
+        {
+        	ninthTierAltar.add(new AltarComponent(24, i, 24, AlchemicalWizardry.specialAltarBlock[11].getBlock(), AlchemicalWizardry.specialAltarBlock[11].getMeta(), false, false));
+        	ninthTierAltar.add(new AltarComponent(-24, i, -24, AlchemicalWizardry.specialAltarBlock[11].getBlock(), AlchemicalWizardry.specialAltarBlock[11].getMeta(), false, false));
+        	ninthTierAltar.add(new AltarComponent(24, i, -24, AlchemicalWizardry.specialAltarBlock[11].getBlock(), AlchemicalWizardry.specialAltarBlock[11].getMeta(), false, false));
+        	ninthTierAltar.add(new AltarComponent(-24, i, 24, AlchemicalWizardry.specialAltarBlock[11].getBlock(), AlchemicalWizardry.specialAltarBlock[11].getMeta(), false, false));
+        }
+        ninthTierAltar.add(new AltarComponent(24, 10, 24, AlchemicalWizardry.specialAltarBlock[12].getBlock(), AlchemicalWizardry.specialAltarBlock[12].getMeta(), false, false));
+        ninthTierAltar.add(new AltarComponent(-24, 10, -24, AlchemicalWizardry.specialAltarBlock[12].getBlock(), AlchemicalWizardry.specialAltarBlock[12].getMeta(), false, false));
+        ninthTierAltar.add(new AltarComponent(24, 10, -24, AlchemicalWizardry.specialAltarBlock[12].getBlock(), AlchemicalWizardry.specialAltarBlock[12].getMeta(), false, false));
+        ninthTierAltar.add(new AltarComponent(-24, 10, 24, AlchemicalWizardry.specialAltarBlock[12].getBlock(), AlchemicalWizardry.specialAltarBlock[12].getMeta(), false, false));
+        //bases for 9th
+        ninthTierAltar.add(new AltarComponent(23, -7, 24, AlchemicalWizardry.specialAltarBlock[10].getBlock(), AlchemicalWizardry.specialAltarBlock[10].getMeta(), false, false));
+        ninthTierAltar.add(new AltarComponent(25, -7, 24, AlchemicalWizardry.specialAltarBlock[10].getBlock(), AlchemicalWizardry.specialAltarBlock[10].getMeta(), false, false));
+        ninthTierAltar.add(new AltarComponent(24, -7, 24, AlchemicalWizardry.specialAltarBlock[10].getBlock(), AlchemicalWizardry.specialAltarBlock[10].getMeta(), false, false));
+        ninthTierAltar.add(new AltarComponent(24, -7, 23, AlchemicalWizardry.specialAltarBlock[10].getBlock(), AlchemicalWizardry.specialAltarBlock[10].getMeta(), false, false));
+        ninthTierAltar.add(new AltarComponent(24, -7, 25, AlchemicalWizardry.specialAltarBlock[10].getBlock(), AlchemicalWizardry.specialAltarBlock[10].getMeta(), false, false));
+        for (int i = 22; i <= 26; i++) {
+        	ninthTierAltar.add(new AltarComponent(i, -8, 23, AlchemicalWizardry.specialAltarBlock[10].getBlock(), AlchemicalWizardry.specialAltarBlock[10].getMeta(), false, false));
+        	ninthTierAltar.add(new AltarComponent(i, -8, 24, AlchemicalWizardry.specialAltarBlock[10].getBlock(), AlchemicalWizardry.specialAltarBlock[10].getMeta(), false, false));
+        	ninthTierAltar.add(new AltarComponent(i, -8, 25, AlchemicalWizardry.specialAltarBlock[10].getBlock(), AlchemicalWizardry.specialAltarBlock[10].getMeta(), false, false));
+        	ninthTierAltar.add(new AltarComponent(i, -8, -23, AlchemicalWizardry.specialAltarBlock[10].getBlock(), AlchemicalWizardry.specialAltarBlock[10].getMeta(), false, false));
+        	ninthTierAltar.add(new AltarComponent(i, -8, -24, AlchemicalWizardry.specialAltarBlock[10].getBlock(), AlchemicalWizardry.specialAltarBlock[10].getMeta(), false, false));
+        	ninthTierAltar.add(new AltarComponent(i, -8, -25, AlchemicalWizardry.specialAltarBlock[10].getBlock(), AlchemicalWizardry.specialAltarBlock[10].getMeta(), false, false));
+        }
+        for (int i = 23; i <= 25; i++) {
+        	ninthTierAltar.add(new AltarComponent(i, -8, 22, AlchemicalWizardry.specialAltarBlock[10].getBlock(), AlchemicalWizardry.specialAltarBlock[10].getMeta(), false, false));
+        	ninthTierAltar.add(new AltarComponent(i, -8, 26, AlchemicalWizardry.specialAltarBlock[10].getBlock(), AlchemicalWizardry.specialAltarBlock[10].getMeta(), false, false));
+        	ninthTierAltar.add(new AltarComponent(i, -8, -22, AlchemicalWizardry.specialAltarBlock[10].getBlock(), AlchemicalWizardry.specialAltarBlock[10].getMeta(), false, false));
+        	ninthTierAltar.add(new AltarComponent(i, -8, -26, AlchemicalWizardry.specialAltarBlock[10].getBlock(), AlchemicalWizardry.specialAltarBlock[10].getMeta(), false, false));
+        }
+        for (int i = -26; i <= -22; i++) {
+        	ninthTierAltar.add(new AltarComponent(i, -8, 23, AlchemicalWizardry.specialAltarBlock[10].getBlock(), AlchemicalWizardry.specialAltarBlock[10].getMeta(), false, false));
+        	ninthTierAltar.add(new AltarComponent(i, -8, 24, AlchemicalWizardry.specialAltarBlock[10].getBlock(), AlchemicalWizardry.specialAltarBlock[10].getMeta(), false, false));
+        	ninthTierAltar.add(new AltarComponent(i, -8, 25, AlchemicalWizardry.specialAltarBlock[10].getBlock(), AlchemicalWizardry.specialAltarBlock[10].getMeta(), false, false));
+        	ninthTierAltar.add(new AltarComponent(i, -8, -23, AlchemicalWizardry.specialAltarBlock[10].getBlock(), AlchemicalWizardry.specialAltarBlock[10].getMeta(), false, false));
+        	ninthTierAltar.add(new AltarComponent(i, -8, -24, AlchemicalWizardry.specialAltarBlock[10].getBlock(), AlchemicalWizardry.specialAltarBlock[10].getMeta(), false, false));
+        	ninthTierAltar.add(new AltarComponent(i, -8, -25, AlchemicalWizardry.specialAltarBlock[10].getBlock(), AlchemicalWizardry.specialAltarBlock[10].getMeta(), false, false));
+        }
+        for (int i = -25; i <= -23; i++) {
+        	ninthTierAltar.add(new AltarComponent(i, -8, 22, AlchemicalWizardry.specialAltarBlock[10].getBlock(), AlchemicalWizardry.specialAltarBlock[10].getMeta(), false, false));
+        	ninthTierAltar.add(new AltarComponent(i, -8, 26, AlchemicalWizardry.specialAltarBlock[10].getBlock(), AlchemicalWizardry.specialAltarBlock[10].getMeta(), false, false));
+        	ninthTierAltar.add(new AltarComponent(i, -8, -22, AlchemicalWizardry.specialAltarBlock[10].getBlock(), AlchemicalWizardry.specialAltarBlock[10].getMeta(), false, false));
+        	ninthTierAltar.add(new AltarComponent(i, -8, -26, AlchemicalWizardry.specialAltarBlock[10].getBlock(), AlchemicalWizardry.specialAltarBlock[10].getMeta(), false, false));
+        }
+        
+        for (int i = -20; i <= 20; i++)
+        {
+        	ninthTierAltar.add(new AltarComponent(24, -8, i, AlchemicalWizardry.ninthTierRunes[0].getBlock(), AlchemicalWizardry.ninthTierRunes[0].getMeta(), true, true));
+        	ninthTierAltar.add(new AltarComponent(-24, -8, i, AlchemicalWizardry.ninthTierRunes[0].getBlock(), AlchemicalWizardry.ninthTierRunes[0].getMeta(), true, true));
+        	ninthTierAltar.add(new AltarComponent(i, -8, 24, AlchemicalWizardry.ninthTierRunes[0].getBlock(), AlchemicalWizardry.ninthTierRunes[0].getMeta(), true, true));
+        	ninthTierAltar.add(new AltarComponent(i, -8, -24, AlchemicalWizardry.ninthTierRunes[0].getBlock(), AlchemicalWizardry.ninthTierRunes[0].getMeta(), true, true));
+        }      
     }
 
     public static List<AltarComponent> getAltarUpgradeListForTier(int tier)
@@ -301,6 +487,15 @@ public class UpgradedAltars
 
             case 6:
             	return sixthTierAltar;
+            	
+            case 7:
+            	return seventhTierAltar;
+            	
+            case 8:
+            	return eighthTierAltar;
+            	
+            case 9:
+            	return ninthTierAltar;
         }
 
         return null;

--- a/src/main/java/WayofTime/alchemicalWizardry/common/tileEntity/TEAltar.java
+++ b/src/main/java/WayofTime/alchemicalWizardry/common/tileEntity/TEAltar.java
@@ -934,7 +934,7 @@ public class TEAltar extends TEInventory implements IFluidTank, IFluidHandler, I
     {
         player.addChatMessage(new ChatComponentTranslation(String.format("message.altar.currentessence"), this.fluid.amount));
         player.addChatMessage(new ChatComponentTranslation(String.format("message.altar.currenttier"), UpgradedAltars.isAltarValid(worldObj, xCoord, yCoord, zCoord)));
-        player.addChatMessage(new ChatComponentTranslation(String.format("message.altar.capacity"), this.getCapacity()));
+        player.addChatMessage(new ChatComponentTranslation(String.format("message.altar.capacity"), this.getCapacity()));//doesn't work anymore? Why?
     }
 
     public void sendMoreChatInfoToPlayer(EntityPlayer player)


### PR DESCRIPTION
No idea why it works even if I didn't increase the size at https://github.com/Prometheus0000/BloodMagic/compare/1.7.10...Prometheus0000:add-altar-tiers?expand=1#diff-833ca15437d8027eed94e409f69cfa967a3eef5cd816900e2c3b7b1f9de26e12R308 Are these not normal arrays? Or do arrays not need amount to be declared? then why declare it before? And why is it 1 more than the number used?

The divination sigil also stopped showing the altar capacity for some reason, though I don't know where in the previous changes that happened, and I shouldn't have caused any changes to it either. It could probably be fixed by just doing the same thing the 
sight sigil does with this.capacity instead of this.getCapacity(), but I'd like to know why it broke instead.

The materials of the new tiers are temp, since we'll just change them via config anyway. You'll probably need to go to the wiki and look at a picture to understand how to build it honestly. The bases use the previous tier's caps as material. Though this could be changed.

![2020-10-28_19 22 30](https://user-images.githubusercontent.com/8517039/97507162-fe561880-1952-11eb-8a08-65bfdd81d4b3.png)
![2020-10-28_19 22 15](https://user-images.githubusercontent.com/8517039/97507173-01e99f80-1953-11eb-8633-c5ba1767474d.png)

